### PR TITLE
add support for recent glslify

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glslify-import",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "A transform stream for glslify that adds an `import` directive to your shaders.",
   "main": "index.js",
   "dependencies": {
@@ -9,7 +9,7 @@
     "glsl-tokenizer": "^2.0.2"
   },
   "devDependencies": {
-    "glslify": "^2.1.2",
+    "glslify": "^6.1.0",
     "tap-spec": "^3.0.0",
     "tape": "^4.0.0"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -7,42 +7,35 @@ const basic = path.join(__dirname, 'fixtures', 'basic-origin.glsl')
 const importRequire = path.join(__dirname, 'fixtures', 'import-with-require.glsl')
 
 test('glslify-import: basic', function (t) {
-  glslify.bundle(basic, {
+  var src = glslify(basic, {
     transform: [ require.resolve('../index.js') ]
-  }, function (err, src) {
-    if (err) throw err
-
-    t.ok(/\sunaltered\s/.exec(src), 'unaltered variable is unaltered')
-    t.ok(/basicRequire/.exec(src), 'basic-require.glsl imported dependency is still included')
-    t.end()
-  })
+  });
+  t.ok(/\sunaltered\s/.exec(src), 'unaltered variable is unaltered')
+  t.ok(/basicRequire/.exec(src), 'basic-require.glsl imported dependency is still included')
+  t.end()
 })
 
 test('glslify-import: recursive', function (t) {
-  glslify.bundle(recursive, {
+  var src = glslify(recursive, {
     transform: [ require.resolve('../index.js') ]
-  }, function (err, src) {
-    if (err) throw err
+  });
 
-    t.ok(/\sunaltered\s/.exec(src), 'unaltered variable is unaltered')
-    t.ok(/basicRequire/.exec(src), 'basic-require.glsl imported dependency is still included')
-    t.ok(!/\#pragma glslify/.exec(src), 'no pragmas remaining')
-    t.equal(src.match(/main\(\)/g).length, 2, '2 copies imported')
-    t.equal(src.match(/\#define GLSLIFY/).length, 1, 'only 1 glslify definition')
-    t.end()
-  })
+  t.ok(/\sunaltered\s/.exec(src), 'unaltered variable is unaltered')
+  t.ok(/basicRequire/.exec(src), 'basic-require.glsl imported dependency is still included')
+  t.ok(!/\#pragma glslify/.exec(src), 'no pragmas remaining')
+  t.equal(src.match(/main\(\)/g).length, 2, '2 copies imported')
+  t.equal(src.match(/\#define GLSLIFY/).length, 1, 'only 1 glslify definition')
+  t.end()
 })
 
 test('glslify-import: require paths modified', function (t) {
-  glslify.bundle(importRequire, {
+  var src = glslify(importRequire, {
     transform: [ require.resolve('../index.js') ]
-  }, function (err, src) {
-    if (err) throw err
+  });
 
-    t.ok(/basicRequire/.exec(src), 'basic-require.glsl imported dependency is still included')
-    t.ok(/subRequire1/.exec(src), 'subfolder-1/basic-require.glsl imported dependency is still included')
-    t.ok(/subRequire2/.exec(src), 'subfolder-2/basic-require.glsl imported dependency is still included')
-    t.ok(!/\#pragma glslify/.exec(src), 'no pragmas remaining')
-    t.end()
-  })
+  t.ok(/basicRequire/.exec(src), 'basic-require.glsl imported dependency is still included')
+  t.ok(/subRequire1/.exec(src), 'subfolder-1/basic-require.glsl imported dependency is still included')
+  t.ok(/subRequire2/.exec(src), 'subfolder-2/basic-require.glsl imported dependency is still included')
+  t.ok(!/\#pragma glslify/.exec(src), 'no pragmas remaining')
+  t.end()
 })


### PR DESCRIPTION
fixes #6

The most recent version of glslify (6.1.0) requires that transforms
export a sync interface. I have left the async interface as is, for
compatiblity with older versions.

I have upgrade the tests to run with the newest version of glslify, but
before doing that, I asserted that the old tests still pass with an old
glslify version.

I have also bumped the version in package.json to 3.1.0, increasing the
minor version because this is not a breaking change.